### PR TITLE
Use generics for typesafe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ task in parallel only after some initial timeout has elapsed:
 
 ```go
 // An example task that will wait for a random amount of time before returning
-task := func(ctx context.Context) (interface{}, error) {
+task := func(ctx context.Context) (string, error) {
     delay := time.Duration(float64(250*time.Millisecond) * rand.Float64())
     select {
     case <-time.After(delay):

--- a/example_test.go
+++ b/example_test.go
@@ -73,14 +73,13 @@ func Example() {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	result, err := speculatively.Do(ctx, patience, func(ctx context.Context) (interface{}, error) {
+	successfulCall, err := speculatively.Do(ctx, patience, func(ctx context.Context) (interface{}, error) {
 		return expensiveTask.Execute(ctx)
 	})
 	if err != nil {
 		fmt.Printf("unexpected error: %s\n", err)
 		return
 	}
-	successfulCall := result.(int)
 	fmt.Printf("succeeded on call number %d\n", successfulCall)
 
 	// Output:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mccutchen/speculatively
 
-go 1.12
+go 1.18


### PR DESCRIPTION
Here we update the speculatively API to use generics for better type safety. This bumps the minimum go version to 1.18.